### PR TITLE
[Chore] Mobile AR 템플릿 에셋 충돌 해결

### DIFF
--- a/2M2W/Assets/Downloads/MobileARTemplateAssets/Scripts/ARTemplateMenuManager.cs
+++ b/2M2W/Assets/Downloads/MobileARTemplateAssets/Scripts/ARTemplateMenuManager.cs
@@ -82,12 +82,16 @@ public class ARTemplateMenuManager : MonoBehaviour
 
     [SerializeField]
     [Tooltip("The object spawner component in charge of spawning new objects.")]
+#pragma warning disable CS0436 // 형식이 가져온 형식과 충돌합니다.
     ObjectSpawner m_ObjectSpawner;
+#pragma warning restore CS0436 // 형식이 가져온 형식과 충돌합니다.
 
     /// <summary>
     /// The object spawner component in charge of spawning new objects.
     /// </summary>
+#pragma warning disable CS0436 // 형식이 가져온 형식과 충돌합니다.
     public ObjectSpawner objectSpawner
+#pragma warning restore CS0436 // 형식이 가져온 형식과 충돌합니다.
     {
         get => m_ObjectSpawner;
         set => m_ObjectSpawner = value;

--- a/2M2W/Assets/Downloads/MobileARTemplateAssets/Scripts/GoalManager.cs
+++ b/2M2W/Assets/Downloads/MobileARTemplateAssets/Scripts/GoalManager.cs
@@ -108,12 +108,16 @@ public class GoalManager : MonoBehaviour
 
     [Tooltip("Object Spawner used to detect whether the spawning goal has been achieved.")]
     [SerializeField]
+#pragma warning disable CS0436 // 형식이 가져온 형식과 충돌합니다.
     ObjectSpawner m_ObjectSpawner;
+#pragma warning restore CS0436 // 형식이 가져온 형식과 충돌합니다.
 
     /// <summary>
     /// Object Spawner used to detect whether the spawning goal has been achieved.
     /// </summary>
+#pragma warning disable CS0436 // 형식이 가져온 형식과 충돌합니다.
     public ObjectSpawner objectSpawner
+#pragma warning restore CS0436 // 형식이 가져온 형식과 충돌합니다.
     {
         get => m_ObjectSpawner;
         set => m_ObjectSpawner = value;


### PR DESCRIPTION
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
---
Mobile AR 템플릿 에셋 충돌을 해결하였습니다.

# 변경된 기능에 대한 설명
---

- Mobile AR 템플릿 에셋 충돌을 해결하였습니다.
> ObjectSpawner 선언부에서 GoalManager와 ARTemplateAssets 스크립트의 충돌이 존재하였습니다.
이를 경고 알림을 일시적으로 중단시켜 임시로 해결하였습니다.

# 시각 자료
---
![image](https://github.com/Gongju-Unity-Bootcamp/2M2W/assets/15951166/2df57c97-b589-4be9-b65d-c8046c873732)

# 관련 이슈
---
- [] #4